### PR TITLE
fix(docs): update link paths in measure-tutorials index

### DIFF
--- a/src/content/docs/measure_iq/index.md
+++ b/src/content/docs/measure_iq/index.md
@@ -13,7 +13,6 @@ Measure IQ is Behavure's advanced measurement and analytics platform that helps 
 
 - [Measure IQ Admin Guide](measure_iq/admin-guides) - Setup and administration documentation
 - [Key Concepts](measure_iq/key-concepts-and-terminology) - Essential concepts and terminology
-- [Measure IQ Guides](measure_iq/measure-guides) - Detailed guides for using Measure IQ
 - [Measure IQ Tutorials](measure_iq/measure-tutorials) - Step-by-step tutorials
 - [Measure IQ User Guide](measure_iq/measure-user-guides) - Comprehensive user documentation
 - [Glossary](measure_iq/glossary) - Definitions of key terms in Measure IQ

--- a/src/content/docs/measure_iq/measure-tutorials/index.md
+++ b/src/content/docs/measure_iq/measure-tutorials/index.md
@@ -1,30 +1,35 @@
 ---
-title: "Measure IQ Tutorials "
-description: "Definition & use of Measure IQ Tutorials "
+title: "Measure IQ Tutorials"
+description: "Definition & use of Measure IQ Tutorials"
 ---
 
 The Measure IQ Tutorials are for users who are new to Scuba Analytics. These tasks introduce you to the user interface, walk through creating and modifying queries and flows, and describe how to analyze and share the results.
 
 You can perform this series of tasks sequentially to familiarize yourself with using Measure IQ, or you can jump directly to a specific task you need help completing.
 
-- [Start working with queries and panels](/measure_iq/create-a-board-with-queries-panels)
-- Learn how to create a panel, create and modify a query, and create event and actor properties.
-- [Create a board and add a panel](/measure_iq/create-a-board-with-queries-panels)Once you're familiar with any boards or queries in your workspace when you first log into Measure IQ, you'll want to create your own custom board. This article walks you through that process.
-- [Modify a query](/measure_iq/modify-a-query)This article demonstrates modifying a query from Explore and from a panel, starting with the query example from Create a board and add a panel.
-- [Create an event property](/measure_iq/create-an-event-property)This article describes how to define a new event property. Use an event property in a query to summarize, group by, or filter on a reusable expression.
-- [Create an actor property](/measure_iq/create-an-actor-property)An actor is the someone or something that performs an event. An actor can be a user, a physical object (such as a device), a digital object (like a service), or a bot.
-- [Work with flows](/measure_iq/work-with-flows)
-- Learn how to create, analyze, and modify a flow.
-- [Create a flow](/measure_iq/work-with-flows/create-a-flow)A flow helps you visualize the path of actions taken by a group of actors.
-- [Analyze a flow](/measure_iq/work-with-flows/analyze-a-flow)This article demonstrates a few ways you can inspect a flow and start analyzing results in the flow builder.
-- [Create a flow property](/measure_iq/work-with-flows/create-a-flow-property)When you create a flow, you can choose from a default set of properties. You can also create custom flow properties. Adding custom properties to a flow is similar to running ad hoc queries.
-- [Work with queries](/measure_iq/work-with-queries)
-- Learn how to work with queries, perform calculations and determine ratios
-- [Calculate DAU and MAU](/measure_iq/work-with-queries/calculate-dau-and-mau).
-- [Determine a ratio](/measure_iq/work-with-queries/determine-a-ratio)This article demonstrates how to construct a query using two measures, then how to determine the ratio between the two measures.
-- [Manage objects and queries](/measure_iq/manage-objects-and-queries)
-- Personalize your workspace by controlling the display of objects you've created or that have been shared with you, inspect query history, and manage objects.
-- [Change the visibility of properties](/measure_iq/manage-objects-and-queries/change-the-visibility-of-properties)Manage your workspace by changing the display of properties that you've created or that have been shared with you.
-- [Manage properties](/measure_iq/manage-objects-and-queries/manage-properties)After your property lists become extensive, you'll still want to be able to find the properties you need quickly. This article shows you how to search (filter) for properties, as well as how to delete obsolete properties.
-- [View query history](/measure_iq/manage-objects-and-queries/view-query-history)Measure IQ preserves the session query history, on a per-user basis. This is helpful when you want to return to a query from the current browser session, or return to a query you ran during an earlier session. Measure IQ lets you view past queries with data from when the queries were originally run. You can use these queries as jumping off points from which to create new queries.
-- [Next steps](/measure_iq/manage-objects-and-queries/next-steps)After completing the Measure IQ tutorial, you can continue to enhance your Measure IQ skills and deepen your expertise in exploring data for behavioral analytics. The following resources provide a broad base for continued learning.
+## Working with Queries and Panels
+
+- [Start working with queries and panels](/measure_iq/measure-tutorials/create-a-board-with-queries-panels) - Learn how to create a panel, create and modify a query, and create event and actor properties.
+- [Create a board and add a panel](/measure_iq/measure-tutorials/create-a-board-with-queries-panels) - Learn how to create your own custom board when you're familiar with the workspace.
+- [Modify a query](/measure_iq/measure-tutorials/modify-a-query) - Learn how to modify a query from Explore and from a panel.
+- [Create an event property](/measure_iq/measure-tutorials/create-an-event-property) - Learn how to define a new event property for summarizing, grouping, or filtering.
+- [Create an actor property](/measure_iq/measure-tutorials/create-an-actor-property) - Learn about actors and how to create actor properties.
+
+## Working with Flows
+
+- [Work with flows](/measure_iq/measure-tutorials/work-with-flows) - Learn how to create, analyze, and modify a flow.
+- [Create a flow](/measure_iq/measure-tutorials/work-with-flows/create-a-flow) - Learn how to visualize the path of actions taken by actors.
+- [Analyze a flow](/measure_iq/measure-tutorials/work-with-flows/analyze-a-flow) - Discover ways to inspect and analyze results in the flow builder.
+- [Create a flow property](/measure_iq/measure-tutorials/work-with-flows/create-a-flow-property) - Learn how to create and work with custom flow properties.
+
+## Working with Queries
+
+- [Calculate DAU and MAU](/measure_iq/measure-tutorials/work-with-queries/calculate-dau-and-mau) - Learn how to calculate daily and monthly active users.
+- [Determine a ratio](/measure_iq/measure-tutorials/work-with-queries/determine-a-ratio) - Learn how to construct queries using two measures and determine ratios.
+
+## Managing Objects and Queries
+
+- [Change the visibility of properties](/measure_iq/measure-tutorials/manage-objects-and-queries/change-the-visibility-of-properties) - Learn how to manage the display of properties in your workspace.
+- [Manage properties](/measure_iq/measure-tutorials/manage-objects-and-queries/manage-properties) - Learn how to search for properties and manage your property lists.
+- [View query history](/measure_iq/measure-tutorials/manage-objects-and-queries/view-query-history) - Learn how to access and use your query history.
+- [Next steps](/measure_iq/measure-tutorials/manage-objects-and-queries/next-steps) - Discover resources for continuing your Measure IQ learning journey.


### PR DESCRIPTION
All links in the measure-tutorials index page were using inconsistent path formats. Standardized all links to use absolute paths starting with /measure_iq/measure-tutorials/ to ensure proper navigation throughout the documentation.

- Changed relative paths (../measure-tutorials/) to absolute paths
- Updated all links to follow consistent /measure_iq/measure-tutorials/ format
- Fixed broken navigation links in all sections