### PR TITLE
chore(dev): add .cursorignore for AI assistant optimization

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,76 @@
+# Cursor Rules for Astrodocs Website
+# Last Updated: 2025-04-02
+
+# Build outputs
+dist/
+.output/
+.astro/
+.vercel/
+.netlify/
+.cloudflare/
+
+# Node modules
+node_modules/
+
+# Cache directories
+.cache/
+.npm/
+.pnpm-store/
+
+# Environment variables and secrets
+.env
+.env.*
+!.env.example
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Astro specific files
+public/
+src/content/docs/_generated/
+src/content/config.ts
+
+# Large media files
+*.mp4
+*.webm
+*.mov
+*.avi
+*.mp3
+*.wav
+*.flac
+*.pdf
+*.zip
+*.tar.gz
+
+# Temporary files
+*.log
+*.log.*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# OS specific files
+.DS_Store
+Thumbs.db
+
+# Optional: Limit processing of large markdown files
+# src/content/docs/**/*.md:size>500KB
+
+# Exclude certain folders from search
+# Uncomment if needed:
+# src/content/blog/:noindex
+# src/components/examples/:noindex
+
+# Exclude code from language models if needed
+# Uncomment if needed:
+# src/utils/analytics.ts:nolm
+# src/utils/tracking.ts:nolm


### PR DESCRIPTION
- Exclude build outputs, node modules, and cache directories
- Ignore environment variables and editor config files
- Skip large media files and generated documentation
- Add commented options for size-based and directory-specific exclusions