### PR TITLE
docs(edge_iq): update macOS binaries and installation notes

### DIFF
--- a/src/content/docs/edge_iq/start/04-downloads.mdx
+++ b/src/content/docs/edge_iq/start/04-downloads.mdx
@@ -27,13 +27,21 @@ Refer to the [installation guide](/edge_iq/install/overview) for installation & 
 
 ## Latest stable release (v1.1.3)
 
-| OS            | Architecture | Download                                                                                        | Checksum (SHA256)                                                                               |
-| ------------- | ------------ | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Linux (gnu)   | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-gnu.tar.xz) (tar.xz)   | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-gnu.tar.xz.sha256)   |
-| Linux (musl)  | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-musl.tar.xz) (tar.xz)  | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-musl.tar.xz.sha256)  |
-| Linux (gnu)   | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-gnu.tar.xz) (tar.xz)  | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-gnu.tar.xz.sha256)  |
-| Linux (musl)  | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-musl.tar.xz) (tar.xz) | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-musl.tar.xz.sha256) |
-| Darwin / Mac  | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-apple-darwin.tar.xz) (tar.xz)        | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-apple-darwin.tar.xz.sha256)        |
-| Darwin / Mac  | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-apple-darwin.tar.xz) (tar.xz)       | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-apple-darwin.tar.xz.sha256)       |
-| Windows       | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.zip) (zip)           | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.zip.sha256)        |
-| Windows (MSI) | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.msi) (msi)           | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.msi.sha256)        |
+:::caution
+**macOS Users**: We're actively working code signing for the macOS binary. After downloading EdgeIQ for macOS, run the following command to remove the quarantine attribute:
+
+```
+xattr -d com.apple.quarantine ./edgeiq
+```
+
+:::
+
+| OS           | Architecture | Download                                                                                        | Checksum (SHA256)                                                                               |
+| ------------ | ------------ | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Linux (gnu)  | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-gnu.tar.xz) (tar.xz)   | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-gnu.tar.xz.sha256)   |
+| Linux (musl) | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-musl.tar.xz) (tar.xz)  | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-unknown-linux-musl.tar.xz.sha256)  |
+| Linux (gnu)  | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-gnu.tar.xz) (tar.xz)  | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-gnu.tar.xz.sha256)  |
+| Linux (musl) | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-musl.tar.xz) (tar.xz) | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-unknown-linux-musl.tar.xz.sha256) |
+| Darwin / Mac | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-apple-darwin.zip) (zip)              | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-apple-darwin.zip.sha256)           |
+| Darwin / Mac | aarch64      | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-apple-darwin.zip) (zip)             | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-aarch64-apple-darwin.zip.sha256)          |
+| Windows      | x86-64       | [stable](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.zip) (zip)           | [checksum](https://downloads.behavure.ai/1.1.3/edgeiq-x86_64-pc-windows-msvc.zip.sha256)        |


### PR DESCRIPTION
- Update macOS binaries to use zip format instead of tar.xz
- Add caution note about code signing and quarantine attribute
- Remove Windows MSI installer due to current UX limitations