### PR TITLE
docs(install/macOS): update server/worker guides for package installer

### DIFF
--- a/src/content/docs/edge_iq/install/macOS/10-server.md
+++ b/src/content/docs/edge_iq/install/macOS/10-server.md
@@ -1,76 +1,60 @@
 ---
 title: macOS Server Installation
-description: macOS Server Installation
+description: macOS Server Installation Guide for EdgeIQ
 slug: install/macos/server
 sidebar:
   label: Server Installation
   order: 10
 ---
 
-## Quick Start on macOS (Apple Silicon and Intel)
+## Installation using Package Installer
 
-To quickly install and run EdgeIQ on macOS:
+Installing EdgeIQ on macOS (Apple Silicon and Intel) is straightforward using the provided package installer (`.pkg` file).
 
-1. **Download the Latest Binary**  
-   Visit the [downloads page](https://docs.behavure.ai/start/downloads/) or use this direct link for macOS:
+1.  **Download the Installer**  
+    Visit the [downloads page](https://docs.behavure.ai/start/downloads/) to get the latest macOS installer (`.pkg` file).
 
-   ```
-   http://downloads.behavure.ai/latest/edgeiq-aarch64-apple-darwin.tar.xz
-   ```
+2.  **Run the Installer**  
+    Double-click the downloaded `.pkg` file and follow the installation prompts. The installer will place the `edgeiq` binary in `/usr/local/bin`.
 
-2. **Extract the Binary**  
-   Open Terminal and run:
+3.  **Verify Installation**  
+    Open Terminal. The installer automatically adds `/usr/local/bin` to your system's `PATH`. You should be able to run the `edgeiq` command directly:
 
-   ```
-   tar -xf edgeiq-aarch64-apple-darwin.tar.xz
-   ```
+    ```bash
+    edgeiq --version
+    ```
 
-3. **Move the Binary to Your PATH**  
-   Move the extracted binary to a folder in your `PATH`, such as `/usr/local/bin`:
+    If the command is not found, ensure `/usr/local/bin` is included in your `$PATH` environment variable. You might need to restart your terminal session or source your shell profile file (e.g., `~/.zshrc` or `~/.bash_profile`).
 
-   ```
-   sudo mv edgeiq /usr/local/bin
-   ```
+    ```bash
+    echo $PATH
+    # If /usr/local/bin is missing, add it to your shell profile
+    # For zsh: echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+    # For bash: echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile && source ~/.bash_profile
+    ```
 
-4. **Run EdgeIQ**  
-   Start the server with:
+4.  **Allow Execution (If Necessary)**  
+    Depending on your macOS security settings, you might need to grant permission for the binary to run. If you encounter a security warning, go to **System Settings** → **Privacy & Security** and allow the application.
 
-   ```
-   edgeiq run server
-   ```
+## Server Configuration and Startup
 
-   The server runs on `http://localhost:3000` by default.
+After installing the `edgeiq` binary, configure and start the server.
 
-5. **Log In**  
-   After startup, the terminal will show a randomly generated admin password. Use this to log in as `admin` via the browser.
-
-> **Tip:** You may need to allow the binary to run via System Preferences → Security & Privacy if macOS flags it as unverified.
-
-## Manual Installation
-
-If you prefer to set up the server manually, follow these steps:
-
-1. Create a data directory
-2. Configure environment variables
-3. Start the Server
-
-By the end of this section, you should be able to access the Server via a browser.
-
-## Create a Data Directory
+### Create a Data Directory
 
 The Server requires a data directory to store Jobs, logs, and metric data.
 
 Create a directory for EdgeIQ data:
 
-```
+```bash
 mkdir -p ~/Library/Application\ Support/EdgeIQ
 ```
 
-## Configure Environment Variables
+### Configure Environment Variables
 
-The Server can be configured through environment variables. Create a shell script to set these variables:
+The Server can be configured through environment variables. Create a shell script to set these variables, ensuring you have write permissions or use `sudo` if necessary:
 
-```
+```bash
 cat > ~/edgeiq-server.env << EOF
 EDGEIQ_STAGING_DIR=~/Library/Application\ Support/EdgeIQ
 EDGEIQ_LICENSE_EULA_ACCEPT=yes
@@ -93,16 +77,18 @@ Upon first initialization of the Server user database, if `EDGEIQ_ADMIN_INIT_PAS
 Whether using `EDGEIQ_ADMIN_INIT_PASSWORD`, or the randomly generated `password` on first run, change the `admin` `password` immediately!
 :::
 
-## Start the Server
+### Start the Server
 
 To start the server with the environment variables:
 
-```
+```bash
 source ~/edgeiq-server.env
 edgeiq run server
 ```
 
-The Server will be listening on `EDGEIQ_BIND_ADDRESS` (default `127.0.0.1:3000`).
+The Server will start and listen on `EDGEIQ_BIND_ADDRESS` (default `127.0.0.1:3000`).
+
+The terminal will display the admin password (either the one you set or a randomly generated one) upon successful startup. Use this to log in as `admin` via your web browser at `http://localhost:3000`.
 
 :::tip
 The Server can be configured to use `TLS`, by providing a certificate and key file. See `edgeiq server run --help`.


### PR DESCRIPTION
Updates macOS server and worker installation docs for the `.pkg` installer. Removes manual binary download steps, adds `PATH` verification, and adjusts config instructions.